### PR TITLE
Call G_HistoricalTrace instead of just trap_Trace. G_HistoricalTrace …

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1649,7 +1649,7 @@ void Bullet_Fire_Extended( gentity_t *source, gentity_t *attacker, vec3_t start,
 
 	damage *= s_quadFactor;
 
-	trap_Trace (&tr, start, NULL, NULL, end, source->s.number, MASK_SHOT);
+	G_HistoricalTrace(source, &tr, start, NULL, NULL, end, source->s.number, MASK_SHOT);
 
 	// nihi added below
 	 // L0 - antilag


### PR DESCRIPTION
…attaches the head before tracing so that it'll get picked up by collision detection.