### PR TITLE
Fixes #140 - announcer no longer says 'prepare to fight' incessantly

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -101,7 +101,6 @@ void PauseHandle( void ) {
 		} else {
 			level.paused = PAUSE_UNPAUSING;
 			AP( "print \"Prepare to fight!\n\"" );
-			APS("sound/match/prepare.wav");
 		}
 
 


### PR DESCRIPTION
Fixes announcer saying 'prepare to fight' multiple times.